### PR TITLE
Bug fix

### DIFF
--- a/app.py
+++ b/app.py
@@ -353,7 +353,7 @@ checkpoint_path = "./unipose_swint.pth"  # change the path of the model
 model = load_model(config_file, checkpoint_path, cpu_only=False)
 
 if __name__ == "__main__":
-MARKDOWN = \
+    MARKDOWN = \
 """
 ## UniPose: Detecting Any Keypoints
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 addict==2.4.0
-gradio==4.0.2
+gradio==3.41.2
 ipdb==0.13.4
 matplotlib==3.5.3
 numpy==1.21.5


### PR DESCRIPTION
1. Fix the  `SyntaxError` in `app.py`
2. The following API is only applicable to gradio version 3.xx. The webdemo works fine with version 3.41.
  ```gr.Image(source='')```
  ```gr.outputs.Image()```