### PR TITLE
Updated requirements

### DIFF
--- a/app.py
+++ b/app.py
@@ -366,7 +366,7 @@ If UniPose is helpful for you, please help star the GitHub Repo. Thanks!
     with block:
         with gr.Row():
             with gr.Column():
-                input_image = gr.Image(source='upload', type="pil")
+                input_image = gr.Image(sources=['upload'], type="pil")
                 instance_prompt = gr.Textbox(label="Instance Prompt")
                 keypoint_example = gr.Textbox(label="Keypoint Example",info="Support predefined keypoints: 1) Articulated Objects: person, face, hand, animal_in_AnimalKindom, animal_in_AP10K, animal_face, fly, locust; 2) Rigid Objects: car, table, chair, bed, sofa, swivelchair; 3) Soft Objects: short_sleeved_shirt, long_sleeved_outwear, short_sleeved_outwear, sling, vest, long_sleeved_dress, long_sleeved_shirt, trousers, sling_dress, vest_dress, skirt, short_sleeved_dress, shorts")
                 run_button = gr.Button(label="Run")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 addict==2.4.0
-gradio==4.0.2
+gradio==3.50.0
 ipdb==0.13.4
 matplotlib==3.5.3
 numpy==1.21.5


### PR DESCRIPTION
Gradio (4.0.2) throws multiple errors. Firstly, the gr.Image takes list of sources instead of source. 'source' parameter is not recognized by this version of Gradio.
Secondly, the gr.outputs is also not recognized by this version.
The version '3.5.0' does not give any errors.

All in all, 2 changes:
1. "source" to "sources"
2. gradio==4.0.2 to gradio==3.5.0